### PR TITLE
Statement Triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.DS_Store

--- a/lib/hayfork/delete_sql.rb
+++ b/lib/hayfork/delete_sql.rb
@@ -10,7 +10,7 @@ module Hayfork
 
     def to_sql
       select_statement = relation.select(bindings.map(&:to_s))
-      select_statement = select_statement.from("(SELECT OLD.*) \"#{relation.table_name}\"")
+      select_statement = select_statement.from("old_table \"#{relation.table_name}\"")
 
       constraints = bindings.map { |binding| "#{haystack.table_name}.#{binding.key}=x.#{binding.key}" }.join(" AND ")
 

--- a/lib/hayfork/insert_sql.rb
+++ b/lib/hayfork/insert_sql.rb
@@ -10,7 +10,7 @@ module Hayfork
 
     def to_sql(from: true)
       select_statement = relation.select(bindings.map(&:to_s))
-      select_statement = select_statement.from("(SELECT NEW.*) \"#{relation.table_name}\"") if from
+      select_statement = select_statement.from("new_table \"#{relation.table_name}\"") if from
 
       <<~SQL
         INSERT INTO #{haystack.table_name} (#{bindings.map(&:key).join(", ")}) SELECT * FROM (#{select_statement.to_sql}) "x" WHERE "x"."#{Hayfork::TEXT}" != '';

--- a/lib/hayfork/triggers.rb
+++ b/lib/hayfork/triggers.rb
@@ -52,8 +52,15 @@ module Hayfork
           RETURN NULL; -- result is ignored since this is an AFTER trigger
         END;
         $$ LANGUAGE plpgsql;
-        CREATE TRIGGER #{name}_trigger BEFORE INSERT OR UPDATE OR DELETE ON #{model.table_name}
-        FOR EACH ROW EXECUTE PROCEDURE #{name}();
+        CREATE TRIGGER #{name}_insert_trigger AFTER INSERT ON #{model.table_name}
+          REFERENCING NEW TABLE AS new_table
+          FOR EACH STATEMENT EXECUTE PROCEDURE #{name}();
+        CREATE TRIGGER #{name}_update_trigger AFTER UPDATE ON #{model.table_name}
+          REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+          FOR EACH STATEMENT EXECUTE PROCEDURE #{name}();
+        CREATE TRIGGER #{name}_delete_trigger AFTER DELETE ON #{model.table_name}
+          REFERENCING OLD TABLE AS old_table
+          FOR EACH STATEMENT EXECUTE PROCEDURE #{name}();
       SQL
     end
 

--- a/lib/hayfork/update_sql.rb
+++ b/lib/hayfork/update_sql.rb
@@ -12,13 +12,9 @@ module Hayfork
     end
 
     def to_sql
-      sql = values_to_check_on_update.map { |field| "OLD.#{field} IS DISTINCT FROM NEW.#{field}" }.join(" OR ")
-
       <<-SQL
-    IF #{sql} THEN
       #{delete.to_sql.strip}
       #{insert.to_sql.strip}
-    END IF;
       SQL
     end
     alias to_s to_sql

--- a/lib/hayfork/version.rb
+++ b/lib/hayfork/version.rb
@@ -1,3 +1,3 @@
 module Hayfork
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/test/integration/haystack_test.rb
+++ b/test/integration/haystack_test.rb
@@ -52,16 +52,6 @@ class HaystackTest < Minitest::Test
         ], Haystack.pluck(:search_result_id, :field, :text).to_set
       end
     end
-
-    context "Changing a book's ISBN" do
-      should "do nothing to the haystack if the ISBN isn't used" do
-        book = Book.create!(title: "The Chosen", isbn: "0449213447")
-
-        before = Haystack.pluck(:id)
-        book.update_column :isbn, "9780449213445"
-        assert_equal before, Haystack.pluck(:id)
-      end
-    end
   end
 
 

--- a/test/unit/delete_sql_test.rb
+++ b/test/unit/delete_sql_test.rb
@@ -22,7 +22,7 @@ class DeleteSqlTest < Minitest::Test
           USING (SELECT
             'Book'::varchar "search_result_type",
             books.id::integer "search_result_id"
-          FROM (SELECT OLD.*) "books") "x"
+          FROM old_table "books") "x"
           WHERE haystack.search_result_type=x.search_result_type
           AND haystack.search_result_id=x.search_result_id;
         SQL
@@ -36,7 +36,7 @@ class DeleteSqlTest < Minitest::Test
         DELETE FROM haystack
         USING
           (SELECT 'Book'::varchar "search_result_type"
-          FROM (SELECT OLD.*) "books"
+          FROM old_table "books"
           INNER JOIN "authors" ON "authors"."id" = "books"."author_id"
           WHERE "authors"."name" BETWEEN 'Potok' AND 'Tolkien') "x"
         WHERE haystack.search_result_type=x.search_result_type;

--- a/test/unit/insert_sql_test.rb
+++ b/test/unit/insert_sql_test.rb
@@ -24,7 +24,7 @@ class InsertSqlTest < Minitest::Test
             books.id::integer "search_result_id",
             books.title::text "text",
             setweight(to_tsvector('hayfork', replace(books.title::varchar, '-', ' ')), 'C') "search_vector"
-          FROM (SELECT NEW.*) "books") "x"
+          FROM new_table "books") "x"
           WHERE "x"."text" != '';
         SQL
       end
@@ -36,7 +36,7 @@ class InsertSqlTest < Minitest::Test
       assert_equal <<~SQL.squish, insert.to_sql.strip
         INSERT INTO haystack (search_result_type)
         SELECT * FROM
-          (SELECT 'Book'::varchar "search_result_type" FROM (SELECT NEW.*) "books"
+          (SELECT 'Book'::varchar "search_result_type" FROM new_table "books"
           INNER JOIN "authors" ON "authors"."id" = "books"."author_id"
           WHERE "authors"."name" BETWEEN 'Potok' AND 'Tolkien') "x"
         WHERE "x"."text" != '';

--- a/test/unit/triggers_test.rb
+++ b/test/unit/triggers_test.rb
@@ -38,8 +38,15 @@ class TriggersTest < Minitest::Test
             RETURN NULL; -- result is ignored since this is an AFTER trigger
           END;
           $$ LANGUAGE plpgsql;
-          CREATE TRIGGER maintain_books_in_haystack_trigger BEFORE INSERT OR UPDATE OR DELETE ON books
-          FOR EACH ROW EXECUTE PROCEDURE maintain_books_in_haystack();
+          CREATE TRIGGER maintain_books_in_haystack_insert_trigger AFTER INSERT ON books
+            REFERENCING NEW TABLE AS new_table
+            FOR EACH STATEMENT EXECUTE PROCEDURE maintain_books_in_haystack();
+          CREATE TRIGGER maintain_books_in_haystack_update_trigger AFTER UPDATE ON books
+            REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+            FOR EACH STATEMENT EXECUTE PROCEDURE maintain_books_in_haystack();
+          CREATE TRIGGER maintain_books_in_haystack_delete_trigger AFTER DELETE ON books
+            REFERENCING OLD TABLE AS old_table
+            FOR EACH STATEMENT EXECUTE PROCEDURE maintain_books_in_haystack();
         SQL
       end
 
@@ -67,8 +74,15 @@ class TriggersTest < Minitest::Test
             RETURN NULL; -- result is ignored since this is an AFTER trigger
           END;
           $$ LANGUAGE plpgsql;
-          CREATE TRIGGER maintain_books_in_haystack_trigger BEFORE INSERT OR UPDATE OR DELETE ON books
-          FOR EACH ROW EXECUTE PROCEDURE maintain_books_in_haystack();
+          CREATE TRIGGER maintain_books_in_haystack_insert_trigger AFTER INSERT ON books
+            REFERENCING NEW TABLE AS new_table
+            FOR EACH STATEMENT EXECUTE PROCEDURE maintain_books_in_haystack();
+          CREATE TRIGGER maintain_books_in_haystack_update_trigger AFTER UPDATE ON books
+            REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+            FOR EACH STATEMENT EXECUTE PROCEDURE maintain_books_in_haystack();
+          CREATE TRIGGER maintain_books_in_haystack_delete_trigger AFTER DELETE ON books
+            REFERENCING OLD TABLE AS old_table
+            FOR EACH STATEMENT EXECUTE PROCEDURE maintain_books_in_haystack();
         SQL
       end
     end

--- a/test/unit/update_sql_test.rb
+++ b/test/unit/update_sql_test.rb
@@ -17,38 +17,13 @@ class UpdateSqlTest < Minitest::Test
         ]
       end
 
-      should "check if relevant values have changed before replacing entries in the Haystack" do
+      should "be made up of the SQL to delete and re-insert relevant entries" do
         stub(update).delete.stub!.to_sql.returns("<!-- DELETE -->")
         stub(update).insert.stub!.to_sql.returns("<!-- INSERT -->")
         assert_equal <<~SQL.squish, update.to_sql.squish.strip
-          IF OLD.title IS DISTINCT FROM NEW.title OR OLD.isbn IS DISTINCT FROM NEW.isbn THEN
-            <!-- DELETE -->
-            <!-- INSERT -->
-          END IF;
+          <!-- DELETE -->
+          <!-- INSERT -->
         SQL
-      end
-
-      context "when the model uses attr_readonly" do
-        setup do
-          Book.attr_readonly :isbn
-          fail "isbn should be readonly now" unless Book.readonly_attributes.member?("isbn")
-        end
-
-        teardown do
-          Book.readonly_attributes.delete "isbn"
-          fail "isbn should not be readonly now" if Book.readonly_attributes.member?("isbn")
-        end
-
-        should "not check values that are readonly" do
-          stub(update).delete.stub!.to_sql.returns("<!-- DELETE -->")
-          stub(update).insert.stub!.to_sql.returns("<!-- INSERT -->")
-          assert_equal <<~SQL.squish, update.to_sql.squish.strip
-            IF OLD.title IS DISTINCT FROM NEW.title THEN
-              <!-- DELETE -->
-              <!-- INSERT -->
-            END IF;
-          SQL
-        end
       end
     end
   end


### PR DESCRIPTION
### Summary
Okay, this would be a fairly major change with some meaningful performance implications both ways.

Obviously, in the bulk `INSERT`, `UPDATE`, or `DELETE` cases, we could see a _big_ speed-up from condensing all the trigger function calls down to one statement a piece.

On the other hand, I had to strip out the logic from the update trigger that prevented running the trigger if there were no meaningful changes to indexed properties. This would mean the triggers would run more often, and sometimes unnecessarily, potentially slowing every action down for those tables. 😬 

I _think_ that may be a tradeoff work making? But I'm open to being convinced otherwise. Apart from a change like this, though, I'm not sure how we can efficiently do bulk operations on _many_ records of a table in haystack. Thoughts?